### PR TITLE
Change subtitle start, small things fixed

### DIFF
--- a/subtitles/ZAP Chat/ZAP_Chat_01_Introduction_english.srt
+++ b/subtitles/ZAP Chat/ZAP_Chat_01_Introduction_english.srt
@@ -1,5 +1,5 @@
 1
-00:00:00,000 --> 00:00:11,000
+00:00:05,000 --> 00:00:11,000
 Hello and welcome to a brand new series of videos about the Zed Attack Proxy, otherwise known as ZAP.
 
 2

--- a/subtitles/ZAP Chat/ZAP_Chat_02_Authentication_Tester_english.srt
+++ b/subtitles/ZAP Chat/ZAP_Chat_02_Authentication_Tester_english.srt
@@ -1,5 +1,5 @@
 1
-00:00:00,000 --> 00:00:13,920
+00:00:05,000 --> 00:00:13,920
 Hello and welcome to the first of the ZAP Chat videos and this one is about the authentication
 
 2

--- a/subtitles/ZAP Chat/ZAP_Chat_03_Break_Points_english.srt
+++ b/subtitles/ZAP Chat/ZAP_Chat_03_Break_Points_english.srt
@@ -1,5 +1,5 @@
 1
-00:00:00,000 --> 00:00:12,720
+00:00:05,000 --> 00:00:12,720
 Hello and welcome to a ZAP Chat video about the ZAP break functionality.
 
 2

--- a/subtitles/ZAP Chat/ZAP_Chat_04_ZAPit_english.srt
+++ b/subtitles/ZAP Chat/ZAP_Chat_04_ZAPit_english.srt
@@ -1,5 +1,5 @@
 1
-00:00:00,000 --> 00:00:11,960
+00:00:05,000 --> 00:00:11,960
 Hello, and welcome to a new video in the ZAP Chat series.
 
 2

--- a/subtitles/ZAP Chat/ZAP_Chat_05_Modern_Apps_Part_1_english.srt
+++ b/subtitles/ZAP Chat/ZAP_Chat_05_Modern_Apps_Part_1_english.srt
@@ -1,5 +1,5 @@
 1
-00:00:00,000 --> 00:00:10,440
+00:00:05,000 --> 00:00:10,440
 Hello, and welcome to another episode of ZAP Chat.
 
 2

--- a/subtitles/ZAP Chat/ZAP_Chat_06_Automation_Introduction_english.srt
+++ b/subtitles/ZAP Chat/ZAP_Chat_06_Automation_Introduction_english.srt
@@ -1,5 +1,5 @@
 1
-00:00:00,000 --> 00:00:12,480
+00:00:05,000 --> 00:00:12,480
 Hello and welcome to another ZAP Chat video. Once again, I am joined with by Yiannis.
 
 2
@@ -536,7 +536,7 @@ there's actually a lot of we have a lot of options here and you can actually see
 
 135
 00:13:18,700 --> 00:13:28,860
-go just put baseline minus h then that should give the same list um so one thing you can do
+go just put baseline minus h then that should give the same list so one thing you can do
 
 136
 00:13:28,860 --> 00:13:36,340
@@ -620,7 +620,7 @@ got is we actually have limits on how you know how long to spied for example bec
 
 156
 00:15:23,360 --> 00:15:29,840
-actually um so when i was working at mozilla we configured the baseline scan to run on every
+actually so when i was working at mozilla we configured the baseline scan to run on every
 
 157
 00:15:29,840 --> 00:15:35,440

--- a/subtitles/ZAP Chat/ZAP_Chat_07_Automation_Framework_Part_1_english.srt
+++ b/subtitles/ZAP Chat/ZAP_Chat_07_Automation_Framework_Part_1_english.srt
@@ -1,5 +1,5 @@
 1
-00:00:00,000 --> 00:00:09,720
+00:00:05,000 --> 00:00:09,720
 Hello, and welcome again to another episode of ZAP Chat.
 
 2

--- a/subtitles/ZAP Chat/ZAP_Chat_08_Automation_Framework_Part_2_english.srt
+++ b/subtitles/ZAP Chat/ZAP_Chat_08_Automation_Framework_Part_2_english.srt
@@ -1,5 +1,5 @@
 1
-00:00:00,000 --> 00:00:10,380
+00:00:05,000 --> 00:00:10,380
 Hello, and welcome to another episode of ZAP Chat.
 
 2

--- a/subtitles/ZAP Chat/ZAP_Chat_09_Automation_Framework_Part_3_english.srt
+++ b/subtitles/ZAP Chat/ZAP_Chat_09_Automation_Framework_Part_3_english.srt
@@ -1,5 +1,5 @@
 1
-00:00:00,000 --> 00:00:11,840
+00:00:05,000 --> 00:00:11,840
 Hello, and welcome to another episode of ZAP Chat with me, Simon Bennetts, and Yiannis.
 
 2
@@ -928,7 +928,7 @@ So let's match a string.
 
 233
 00:15:58,800 --> 00:16:06,960
-So Bodg.*t, um, and that is a regex.
+So Bodg.*t and that is a regex.
 
 234
 00:16:07,320 --> 00:16:14,100
@@ -1184,7 +1184,7 @@ payloads and things because it's, I'm not a regex expert, but I use regexes a lo
 
 297
 00:21:19,540 --> 00:21:27,140
-And there's lots of places in ZAP where we use regexes just because they are so flexible, um, and so powerful.
+And there's lots of places in ZAP where we use regexes just because they are so flexible and so powerful.
 
 298
 00:21:27,280 --> 00:21:39,280

--- a/subtitles/ZAP Chat/ZAP_Chat_10_Automation_Framework_Part_4_-_Spidering_english.srt
+++ b/subtitles/ZAP Chat/ZAP_Chat_10_Automation_Framework_Part_4_-_Spidering_english.srt
@@ -1,5 +1,5 @@
 1
-00:00:00,000 --> 00:00:12,000
+00:00:05,000 --> 00:00:12,000
 Hello and welcome to another episode of ZAP Chat with me, Simon Bennetts and Yiannis.
 
 2

--- a/subtitles/ZAP Chat/ZAP_Chat_11_Automation_Framework_Part_5_-_APIs_english.srt
+++ b/subtitles/ZAP Chat/ZAP_Chat_11_Automation_Framework_Part_5_-_APIs_english.srt
@@ -1,5 +1,5 @@
 1
-00:00:00,000 --> 00:00:10,920
+00:00:05,000 --> 00:00:10,920
 Hello and welcome to another ZAP Chat video with myself, Simon, and Yiannis.
 
 2

--- a/subtitles/ZAP Chat/ZAP_Chat_12_Automation_Framework_Part_6_-_Delays_and_Active_Scan_english.srt
+++ b/subtitles/ZAP Chat/ZAP_Chat_12_Automation_Framework_Part_6_-_Delays_and_Active_Scan_english.srt
@@ -1,5 +1,5 @@
 1
-00:00:00,000 --> 00:00:11,760
+00:00:05,000 --> 00:00:11,760
 Hello, and welcome to another episode of ZAP Chat with myself, Simon, and Yiannis.
 
 2

--- a/subtitles/ZAP Chat/ZAP_Chat_13_-_2023_Review_english.srt
+++ b/subtitles/ZAP Chat/ZAP_Chat_13_-_2023_Review_english.srt
@@ -1,5 +1,5 @@
 1
-00:00:00,000 --> 00:00:12,120
+00:00:05,000 --> 00:00:12,120
 Hello, and welcome to the first ZAP Chat of 2024. Happy New Year to everyone.
 
 2
@@ -916,7 +916,7 @@ Many jobs are waiting in the pipeline thanks Ricardo. Yep definitely and then in
 
 230
 00:18:35,740 --> 00:18:42,060
-obviously december's often a bit of a quiet month um but still a lot going on and you know we are
+obviously december's often a bit of a quiet month, but still a lot going on and you know we are
 
 231
 00:18:43,020 --> 00:18:49,020

--- a/subtitles/ZAP Chat/ZAP_Chat_14_Google_Summer_of_Code.srt
+++ b/subtitles/ZAP Chat/ZAP_Chat_14_Google_Summer_of_Code.srt
@@ -1,5 +1,5 @@
 1
-00:00:00,960 --> 00:00:10,880
+00:00:05,000 --> 00:00:10,880
 Hello and welcome to another episode of ZAP Chat with myself and Yiannis.
 
 2
@@ -112,7 +112,7 @@ GSoC back in 2007 when OWASP was flirting with it and it was, you know, it was a
 
 29
 00:02:29,840 --> 00:02:34,460
-question which projects are going to be part of the google summer of code as you say a little bit
+question which projects are going to be part of the Google Summer of Code as you say a little bit
 
 30
 00:02:34,460 --> 00:02:41,780
@@ -120,7 +120,7 @@ of a bum fight like you know who gets the the resources and what what kind of fe
 
 31
 00:02:41,780 --> 00:02:49,220
-has the google summer of code delivered for ZAP? So some of the absolute key ones what i'll do
+has the Google Summer of Code delivered for ZAP? So some of the absolute key ones what i'll do
 
 32
 00:02:49,220 --> 00:02:55,820
@@ -128,7 +128,7 @@ just just while we're mentioning you know here's my t-shirt so so what's happene
 
 33
 00:02:55,820 --> 00:03:02,320
-taken part in google summer of code for quite a few years as part of the OWASP organization.
+taken part in Google Summer of Code for quite a few years as part of the OWASP organization.
 
 34
 00:03:02,320 --> 00:03:08,060
@@ -136,7 +136,7 @@ Obviously, ZAP is no longer part of OWASP we're part of the software security pr
 
 35
 00:03:08,060 --> 00:03:13,900
-part of the linux foundation so we've talked to the linux foundation google summer of code admins
+part of the linux foundation so we've talked to the linux foundation Google Summer of Code admins
 
 36
 00:03:13,900 --> 00:03:18,140
@@ -156,7 +156,7 @@ this happens one way or another. There's a set of companies who are using ZAP
 
 40
 00:03:31,080 --> 00:03:35,780
-and have said they'll sponsor things like this so we want to take part in google summer of code
+and have said they'll sponsor things like this so we want to take part in Google Summer of Code
 
 41
 00:03:35,780 --> 00:03:41,020
@@ -184,7 +184,7 @@ problems and get involved you'll see you've got the contributing guide which is 
 
 47
 00:04:17,860 --> 00:04:23,380
-and lower down here there's a new set of pages we only added recently for google summer of code.
+and lower down here there's a new set of pages we only added recently for Google Summer of Code.
 
 48
 00:04:23,380 --> 00:04:25,780
@@ -216,7 +216,7 @@ three projects which wasn't i i think the first time you take part a project you
 
 55
 00:05:02,020 --> 00:05:07,900
-google summer of code projects, but we ended up with three which is a bit bizarre, but that
+Google Summer of Code projects, but we ended up with three which is a bit bizarre, but that
 
 56
 00:05:07,900 --> 00:05:17,160
@@ -240,11 +240,11 @@ project which wasn't OWASP project so in the end it got transferred to ZAP, beca
 
 61
 00:05:38,140 --> 00:05:43,740
-the Ajax spider and it was a wrapper around crawljax. So the Ajax spider came out of google summer
+the Ajax spider and it was a wrapper around crawljax. So the Ajax spider came out of Google Summer
 
 62
 00:05:43,740 --> 00:05:49,380
-of code and as did a lot of changes to the traditional spider and web socket testing
+of Code and as did a lot of changes to the traditional spider and web socket testing
 
 63
 00:05:49,380 --> 00:05:55,620
@@ -256,11 +256,11 @@ this was it was it was always designed to intended to be ZAP project anyway it w
 
 65
 00:06:01,320 --> 00:06:07,240
-sponsored by mozilla. So we end up mentoring them as well. So very first year google summer
+sponsored by mozilla. So we end up mentoring them as well. So very first year Google Summer of
 
 66
 00:06:07,240 --> 00:06:14,140
-code we mentored three projects which was challenging, but really good. Then 2013
+Code we mentored three projects which was challenging, but really good. Then 2013
 
 67
 00:06:14,140 --> 00:06:20,600
@@ -296,11 +296,11 @@ add-on.. yeah.. very useful and then 2023 the Browser Recorder and Postman Suppo
 
 75
 00:07:15,660 --> 00:07:22,440
-some really significant key developments have been implemented by students working on google
+some really significant key developments have been implemented by students working on Google
 
 76
 00:07:22,440 --> 00:07:25,720
-summer of code. Students and beyond, yeah absolutely
+Summer of Code. Students and beyond, yeah absolutely
 
 77
 00:07:25,800 --> 00:07:34,280

--- a/subtitles/ZAP Chat/ZAP_Chat_15_New_GUI.srt
+++ b/subtitles/ZAP Chat/ZAP_Chat_15_New_GUI.srt
@@ -1,5 +1,5 @@
 1
-00:00:00,000 --> 00:00:10,760
+00:00:05,000 --> 00:00:10,760
 Hello, and welcome to another episode of ZAP Chat with myself and Yiannis.
 
 2


### PR DESCRIPTION
Simon said the subtitles should always start after 5 seconds - I've adjusted that here (I forgot the intro here). In the same breath I deleted some "um's" and standardized Google Summer of Code.